### PR TITLE
Rework CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,131 +9,80 @@ on:
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
-        env:
-          - { NPROC: 2 }
-        platform: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-    env: ${{ matrix.env }}
-
-    name: ${{ matrix.platform }} - ${{ matrix.env.NPROC }} processes
+        platform:
+          - {
+            icon: 🏁,
+            os: windows,
+            shell: msys2,
+            include: /mingw64/include/openssl,
+            lib: /mingw64/lib,
+          }
+          - {
+            icon: 🍎,
+            os: macos,
+            shell: bash --noprofile --norc -eo pipefail,
+            include: /usr/local/opt/openssl/include,
+            lib: /usr/local/opt/openssl/lib,
+          }
+          - {
+            icon: 🐧,
+            os: ubuntu,
+            shell: bash --noprofile --norc -eo pipefail,
+            include: ,
+            lib: ,
+          }
+        sqlite:  [ true, false ]
+        openssl: [ true, false ]
+    name: ${{ matrix.platform.icon }} - SQLITE ${{ matrix.sqlite }} | SSL ${{ matrix.openssl }}
+    runs-on: ${{ matrix.platform.os }}-latest
+    env:
+      NPROC: 2
+    defaults:
+      run:
+        shell: ${{ matrix.platform.shell }} {0}
 
     steps:
+
       - name: Link Homebrew OpenSSL 1.1 to /usr/local/opt/openssl
-        if: startsWith(matrix.platform, 'macos')
-        shell: bash
+        if: matrix.platform.os == 'macos'
         run: |
             rm -f /usr/local/opt/openssl
             ln -s /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
 
-      - name: Install Scoop
-        if: startsWith(matrix.platform, 'windows')
-        shell: powershell
-        run: |
-            iwr -useb get.scoop.sh | iex
-
-      - name: Install external dependencies with Scoop
-        if: startsWith(matrix.platform, 'windows')
-        shell: bash
-        run: |
-          export PATH="${PATH}:${HOME}/scoop/shims"
-          scoop install openssl-mingw
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      # We need to do this because of how github cache works
-      - name: Initialize submodules
-        shell: bash
-        run: |
-          git submodule update --init --recursive
-
-      - name: Cache Nim compiler
-        uses: actions/cache@v2
+      - uses: msys2/setup-msys2@v2
+        if: matrix.platform.os == 'windows'
         with:
-          path: |
-            vendor/nimbus-build-system/vendor/Nim/bin
-          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
+          msystem: MINGW64
+          update: true
+          install: >
+            base-devel
+            git
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-openssl
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions/cache@v2
+        with:
+          path: vendor/nimbus-build-system/vendor/Nim/bin
+          key: ${{ runner.os }}-2-nim-${{ hashFiles('.gitmodules') }}
 
       - name: Install and build dependencies
-        shell: bash
         run: |
-          [[ ${{ matrix.platform }} = windows* ]] && export PATH="${PATH}:${HOME}/scoop/shims"
-          export M="$(which mingw32-make || echo make)"
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 deps
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+          make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 deps
 
-      - name: Build the sqlite.nim wrapper and run tests (static)
-        shell: bash
+      - name: Build the sqlite.nim wrapper and run tests
         run: |
-          [[ ${{ matrix.platform }} = macos* ]] && \
-            export SSL_INCLUDE_DIR=/usr/local/opt/openssl/include && \
-            export SSL_LIB_DIR=/usr/local/opt/openssl/lib
-          [[ ${{ matrix.platform }} = windows* ]] && \
-            export PATH="${PATH}:${HOME}/scoop/shims" && \
-            export SSL_INCLUDE_DIR="${HOME}/scoop/apps/openssl-mingw/current/include" && \
-            export SSL_LIB_DIR="${HOME}/scoop/apps/openssl-mingw/current/lib"
-          export M="$(which mingw32-make || echo make)"
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" \
-                            SSL_INCLUDE_DIR="${SSL_INCLUDE_DIR}" \
-                            SSL_LIB_DIR="${SSL_LIB_DIR}" \
-                            V=1 \
-                            test
-
-      - name: Build the sqlite.nim wrapper and run tests (shared)
-        shell: bash
-        run: |
-          rm -rf nimcache sqlcipher sqlite test/build
-          [[ ${{ matrix.platform }} = macos* ]] && \
-            export SSL_INCLUDE_DIR=/usr/local/opt/openssl/include && \
-            export SSL_LIB_DIR=/usr/local/opt/openssl/lib
-          [[ ${{ matrix.platform }} = windows* ]] && \
-            export PATH="${PATH}:${HOME}/scoop/shims" && \
-            export SSL_INCLUDE_DIR="${HOME}/scoop/apps/openssl-mingw/current/include" && \
-            export SSL_LIB_DIR="${HOME}/scoop/apps/openssl-mingw/current/lib"
-          export M="$(which mingw32-make || echo make)"
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" \
-                            SQLITE_STATIC=false \
-                            SSL_INCLUDE_DIR="${SSL_INCLUDE_DIR}" \
-                            SSL_LIB_DIR="${SSL_LIB_DIR}" \
-                            SSL_STATIC=false \
-                            V=1 \
-                            test
-
-      - name: "Build the sqlite.nim wrapper and run tests (mixed: shared SQLITE)"
-        shell: bash
-        run: |
-          rm -rf nimcache sqlcipher sqlite test/build
-          [[ ${{ matrix.platform }} = macos* ]] && \
-            export SSL_INCLUDE_DIR=/usr/local/opt/openssl/include && \
-            export SSL_LIB_DIR=/usr/local/opt/openssl/lib
-          [[ ${{ matrix.platform }} = windows* ]] && \
-            export PATH="${PATH}:${HOME}/scoop/shims" && \
-            export SSL_INCLUDE_DIR="${HOME}/scoop/apps/openssl-mingw/current/include" && \
-            export SSL_LIB_DIR="${HOME}/scoop/apps/openssl-mingw/current/lib"
-          export M="$(which mingw32-make || echo make)"
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" \
-                            SQLITE_STATIC=false \
-                            SSL_INCLUDE_DIR="${SSL_INCLUDE_DIR}" \
-                            SSL_LIB_DIR="${SSL_LIB_DIR}" \
-                            V=1 \
-                            test
-
-      - name: "Build the sqlite.nim wrapper and run tests (mixed: shared SSL)"
-        shell: bash
-        run: |
-          rm -rf nimcache sqlcipher sqlite test/build
-          [[ ${{ matrix.platform }} = macos* ]] && \
-            export SSL_INCLUDE_DIR=/usr/local/opt/openssl/include && \
-            export SSL_LIB_DIR=/usr/local/opt/openssl/lib
-          [[ ${{ matrix.platform }} = windows* ]] && \
-            export PATH="${PATH}:${HOME}/scoop/shims" && \
-            export SSL_INCLUDE_DIR="${HOME}/scoop/apps/openssl-mingw/current/include" && \
-            export SSL_LIB_DIR="${HOME}/scoop/apps/openssl-mingw/current/lib"
-          export M="$(which mingw32-make || echo make)"
-          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" \
-                            SSL_INCLUDE_DIR="${SSL_INCLUDE_DIR}" \
-                            SSL_LIB_DIR="${SSL_LIB_DIR}" \
-                            SSL_STATIC=false \
-                            V=1 \
-                            test
+          make -j${NPROC} "$@" \
+            NIMFLAGS="--parallelBuild:${NPROC}" \
+            SSL_INCLUDE_DIR="${{ matrix.platform.include }}" \
+            SSL_LIB_DIR="${{ matrix.platform.lib }}" \
+            SQLITE_STATIC=${{ matrix.sqlite }} \
+            SSL_STATIC=${{ matrix.openssl }} \
+            V=1 \
+            test

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,6 @@ SQLITE3_C ?= $(shell pwd)/sqlite/sqlite3.c
 SQLITE3_H ?= $(shell pwd)/sqlite/sqlite3.h
 
 $(SQLITE3_C): | deps
-ifeq ($(detected_OS),Windows)
-	sed -i "s/tr -d '\\\\\\n'/tr -d '\\\\\\r\\\\\\n'/" vendor/sqlcipher/configure
-endif
 	echo -e $(BUILD_MSG) "SQLCipher's SQLite C amalgamation"
 	+ mkdir -p sqlite
 	cd vendor/sqlcipher && \
@@ -130,10 +127,6 @@ endif
 			CFLAGS="$(SQLITE_CDEFS) $(SQLITE_CFLAGS)" \
 			LDFLAGS="$(SQLITE_LDFLAGS) $(SSL_LDFLAGS_SQLITE3_C)" \
 			$(HANDLE_OUTPUT)
-ifeq ($(detected_OS),Windows)
-	sed -i "/TOP =/c\\\\\\TOP := \$$(shell cygpath -m \$$(shell pwd))" vendor/sqlcipher/Makefile
-	sed -i "s/\$$(TCLSH_CMD) \$$(TOP)\\/tool\\/mkshellc.tcl/\$$(TCLSH_CMD) \$$(shell pwd)\\/tool\\/mkshellc.tcl/" vendor/sqlcipher/Makefile
-endif
 	cd vendor/sqlcipher && $(MAKE) sqlite3.c $(HANDLE_OUTPUT)
 	cp \
 		vendor/sqlcipher/sqlite3.c \


### PR DESCRIPTION
This PR updates the CI workflow:

- The matrix is extended to include variables `sqlite` and `openssl` for telling whether to build them statically. As a result, 12 independent jobs are shown in the test suite. include and lib paths are moved to the matrix too.
- The name of each job shows an icon representing the OS, as well as SQLITE and SSL variables.
- On Windows, MSYS2 is used (through Action setup-msys2), instead of Git for Windows. OpenSSL is installed through the package manager. Installed packages are cached by default.
- Option `submodules: recursive` of action/checkout is used, instead of doing it in a `run` step.
