### PR TITLE
feat: handle bool option conversion

### DIFF
--- a/sqlcipher.nim
+++ b/sqlcipher.nim
@@ -134,7 +134,13 @@ proc nilDbValue(): DbValue =
     ## we use this internally.
     DbValue(kind: sqliteNull)
 
-proc fromDbValue*(val: DbValue, T: typedesc[Ordinal]): T = val.intval.T
+proc fromDbValue*(val: DbValue, T: typedesc[Ordinal]): T =
+    when T is bool:
+        if val.kind == DbValueKind.sqliteInteger:
+            return if val.intVal == 0: false else: true
+        elif val.kind == DbValueKind.sqliteText:
+            return val.strVal.parseBool
+    return val.intVal.T
 
 proc fromDbValue*(val: DbValue, T: typedesc[SomeFloat]): float64 = val.floatVal
 

--- a/sqlcipher.nim
+++ b/sqlcipher.nim
@@ -145,7 +145,9 @@ proc fromDbValue*(val: DbValue, T: typedesc[seq[byte]]): seq[byte] = val.blobVal
 proc fromDbValue*(val: DbValue, T: typedesc[DbValue]): T = val
 
 proc fromDbValue*[T](val: DbValue, _: typedesc[Option[T]]): Option[T] =
-    if val.kind == sqliteNull:
+    if (val.kind == sqliteNull) or
+        (val.kind == sqliteText and val.strVal == "") or
+        (val.kind == sqliteInteger and val.intVal == 0):
         none(T)
     else:
         some(val.fromDbValue(T))

--- a/sqlcipher.nim
+++ b/sqlcipher.nim
@@ -136,11 +136,9 @@ proc nilDbValue(): DbValue =
 
 proc fromDbValue*(val: DbValue, T: typedesc[Ordinal]): T =
     when T is bool:
-        if val.kind == DbValueKind.sqliteInteger:
-            return if val.intVal == 0: false else: true
-        elif val.kind == DbValueKind.sqliteText:
+        if val.kind == DbValueKind.sqliteText:
             return val.strVal.parseBool
-    return val.intVal.T
+    val.intVal.T
 
 proc fromDbValue*(val: DbValue, T: typedesc[SomeFloat]): float64 = val.floatVal
 


### PR DESCRIPTION
This is meant to support Windows+shared lib configurations in which case a `bool` value is set by a `sqliteText` variable instead of a `sqliteInteger`.