### PR TITLE
feat: add support for getting row data by column name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "vendor/cligen"]
 	path = vendor/cligen
 	url = https://github.com/c-blake/cligen.git
+[submodule "vendor/nim-stew"]
+	path = vendor/nim-stew
+	url = https://github.com/status-im/nim-stew

--- a/sqlcipher.nim
+++ b/sqlcipher.nim
@@ -362,7 +362,7 @@ proc isReadonly*(db: DbConn): bool =
     sqlite.db_readonly(db, "main") == 1
 ]#
 
-proc col*[T](row: DbRow, columnName: string, _: typedesc[T]): T =
+proc col*[T](row: DbRow, columnName: string): T =
     let results = row.filter((column: DbColumn) => column.name == columnName)
     if results.len == 0:
         return default(T)
@@ -394,6 +394,6 @@ template enumInstanceDbColumns*(obj: auto,
 proc to*(row: DbRow, obj: var object) =
     obj.enumInstanceDbColumns(dbColName, property):
         type ColType = type property
-        property = row.col(dbColName, ColType)
+        property = col[ColType](row, dbColName)
 
 proc hasRows*(rows: seq[DbRow]): bool = rows.len > 0

--- a/sqlcipher.nim
+++ b/sqlcipher.nim
@@ -4,7 +4,7 @@ import std / [options, macros, typetraits], sugar, sequtils
 # To generate it use the `sqlite.nim` target of the Makefile in the same
 # directory as this file.
 from sqlcipher/sqlite as sqlite import nil
-from stew import hasCustomPragmaFixed, getCustomPragmaFixed
+from stew/shims/macros as stew_macros import hasCustomPragmaFixed, getCustomPragmaFixed
 
 # Adapted from https://github.com/GULPF/tiny_sqlite
 
@@ -402,5 +402,7 @@ template enumInstanceDbColumns*(obj: auto,
 
 proc to*(row: seq[DbColumn], obj: var object) =
     obj.enumInstanceDbColumns(dbColName, property):
-        type ColType = type colType
-        property = r.col(dbColName, colType)
+        type ColType = type property
+        property = row.col(dbColName, ColType)
+
+proc hasRows*(rows: seq[seq[DbColumn]]): bool = rows.len > 0


### PR DESCRIPTION
Also support the `.to(T)` proc that allows a row of data (`seq[DbColumn]`) to be typecasted to an object.